### PR TITLE
Add Value Label Decorator

### DIFF
--- a/lib/chart/render/decorations/value_decoration.dart
+++ b/lib/chart/render/decorations/value_decoration.dart
@@ -4,6 +4,10 @@ typedef ValueFromItem = double Function(ChartItem item);
 
 double defaultValueForItem(ChartItem item) => item.max ?? 0.0;
 
+typedef LabelFromItem = String Function(ChartItem item);
+
+String defaultLabelForItem(ChartItem item) => (item.max ?? 0.0).toInt().toString();
+
 /// Draw value of the items on them.
 /// Use this only as [ChartState.foregroundDecorations] in order to be visible at all locations
 /// Exact alignment can be set with [alignment]
@@ -14,6 +18,7 @@ class ValueDecoration extends DecorationPainter {
     this.alignment = Alignment.topCenter,
     this.valueArrayIndex = 0,
     this.valueGenerator = defaultValueForItem,
+    this.labelGenerator = defaultLabelForItem,
   });
 
   /// Style for values to use
@@ -23,6 +28,11 @@ class ValueDecoration extends DecorationPainter {
   final Alignment alignment;
 
   final ValueFromItem valueGenerator;
+
+  /// Generate a custom label that is used.
+  ///
+  /// By default it will display the output from [valueGenerator] parsed to an int
+  final LabelFromItem labelGenerator;
 
   /// Index of list in items, this is used if there are multiple lists in the chart
   ///
@@ -64,7 +74,7 @@ class ValueDecoration extends DecorationPainter {
     final _itemMaxValue = valueGenerator(item);
 
     final _maxValuePainter = ValueDecoration.makeTextPainter(
-      '${_itemMaxValue.toInt()}',
+      labelGenerator(item),
       width,
       textStyle,
     );

--- a/lib/chart/render/decorations/value_decoration.dart
+++ b/lib/chart/render/decorations/value_decoration.dart
@@ -6,8 +6,6 @@ double defaultValueForItem(ChartItem item) => item.max ?? 0.0;
 
 typedef LabelFromItem = String Function(ChartItem item);
 
-String defaultLabelForItem(ChartItem item) => (item.max ?? 0.0).toInt().toString();
-
 /// Draw value of the items on them.
 /// Use this only as [ChartState.foregroundDecorations] in order to be visible at all locations
 /// Exact alignment can be set with [alignment]
@@ -18,7 +16,7 @@ class ValueDecoration extends DecorationPainter {
     this.alignment = Alignment.topCenter,
     this.valueArrayIndex = 0,
     this.valueGenerator = defaultValueForItem,
-    this.labelGenerator = defaultLabelForItem,
+    this.labelGenerator,
   });
 
   /// Style for values to use
@@ -32,7 +30,7 @@ class ValueDecoration extends DecorationPainter {
   /// Generate a custom label that is used.
   ///
   /// By default it will display the output from [valueGenerator] parsed to an int
-  final LabelFromItem labelGenerator;
+  final LabelFromItem? labelGenerator;
 
   /// Index of list in items, this is used if there are multiple lists in the chart
   ///
@@ -74,7 +72,7 @@ class ValueDecoration extends DecorationPainter {
     final _itemMaxValue = valueGenerator(item);
 
     final _maxValuePainter = ValueDecoration.makeTextPainter(
-      labelGenerator(item),
+      labelGenerator?.call(item) ?? '${_itemMaxValue.toInt()}',
       width,
       textStyle,
     );


### PR DESCRIPTION
As mentioned in #42 the labels of a section in a stacked bar chart don't necessarily equal the value where the label should appear. To circumvent this while maintaining the current behaviour for backwards compatibility I have added a way to generate the label that should be used based on the `ChartItem`