### PR TITLE
Moved `golden_toolkit` to `dev_dependencies`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,12 +13,12 @@ dependencies:
     sdk: flutter
 
   collection: ^1.15.0
-  golden_toolkit: ^0.13.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.11.1
+  golden_toolkit: ^0.13.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Is there a reason to have `golden_toolkit` as a normal dependency?