### PR TITLE
Fix error when building the example app 

### DIFF
--- a/example/lib/charts/scrollable_chart_screen.dart
+++ b/example/lib/charts/scrollable_chart_screen.dart
@@ -154,9 +154,7 @@ class _ScrollableChartScreenState extends State<ScrollableChartScreen> {
         SelectedItemDecoration(
           _selected,
           animate: true,
-          // showOnTop: false,
           selectedColor: Theme.of(context).colorScheme.secondary,
-          childHeight: 40.0,
           child: Padding(
             padding: const EdgeInsets.only(bottom: 40.0),
             child: Container(


### PR DESCRIPTION
This fixes the following error when building the example app.

`Error: No named parameter with the name 'childHeight'.`