### PR TITLE
Center Bars

### DIFF
--- a/lib/chart/model/theme/item_theme/bar_item_options.dart
+++ b/lib/chart/model/theme/item_theme/bar_item_options.dart
@@ -19,6 +19,7 @@ class BarItemOptions extends ItemOptions {
     EdgeInsets multiValuePadding = EdgeInsets.zero,
     double? maxBarWidth,
     double? minBarWidth,
+    double startPosition = 0.5,
     Color color = Colors.red,
     ColorForValue? colorForValue,
     ColorForKey? colorForKey,
@@ -34,6 +35,7 @@ class BarItemOptions extends ItemOptions {
           multiValuePadding: multiValuePadding,
           maxBarWidth: maxBarWidth,
           minBarWidth: minBarWidth,
+          startPosition: startPosition,
           geometryPainter: barPainter,
           multiItemStack: multiItemStack,
         );
@@ -43,6 +45,7 @@ class BarItemOptions extends ItemOptions {
     EdgeInsets multiValuePadding = EdgeInsets.zero,
     double? maxBarWidth,
     double? minBarWidth,
+    double startPosition = 0.5,
     Color color = Colors.red,
     ColorForValue? colorForValue,
     ColorForKey? colorForKey,
@@ -58,6 +61,7 @@ class BarItemOptions extends ItemOptions {
           multiValuePadding: multiValuePadding,
           maxBarWidth: maxBarWidth,
           minBarWidth: minBarWidth,
+          startPosition: startPosition,
           geometryPainter: barPainter,
           multiItemStack: multiItemStack,
         );
@@ -90,6 +94,8 @@ class BarItemOptions extends ItemOptions {
           radius, endValue is BarItemOptions ? endValue.radius : null, t),
       maxBarWidth: lerpDouble(maxBarWidth, endValue.maxBarWidth, t),
       minBarWidth: lerpDouble(minBarWidth, endValue.minBarWidth, t),
+      startPosition:
+          lerpDouble(startPosition, endValue.startPosition, t) ?? 0.5,
       border: BorderSide.lerp(
           border ?? BorderSide.none,
           endValue is BarItemOptions

--- a/lib/chart/model/theme/item_theme/item_options.dart
+++ b/lib/chart/model/theme/item_theme/item_options.dart
@@ -25,6 +25,7 @@ abstract class ItemOptions {
     this.multiValuePadding = EdgeInsets.zero,
     this.maxBarWidth,
     this.minBarWidth,
+    this.startPosition = 0.5,
     this.color = Colors.red,
     this.colorForValue,
     this.colorForKey,
@@ -37,6 +38,7 @@ abstract class ItemOptions {
     this.multiValuePadding = EdgeInsets.zero,
     this.maxBarWidth,
     this.minBarWidth,
+    this.startPosition = 0.5,
     this.color = Colors.red,
     this.colorForValue,
     this.colorForKey,
@@ -66,6 +68,15 @@ abstract class ItemOptions {
 
   /// Min width of item in the chart
   final double? minBarWidth;
+
+  /// Set start position.
+  /// This value ranges from 0.0 - 1.0.
+  ///
+  /// 0.0 means that start position is left most point of the item,
+  /// 1.0 means right most point.
+  ///
+  /// By default this is set to 0.5, so items are located in center
+  final double startPosition;
 
   /// Geometry
   final ChartGeometryPainter geometryPainter;

--- a/lib/chart/render/geometry/painters/bar_geometry_painter.dart
+++ b/lib/chart/render/geometry/painters/bar_geometry_painter.dart
@@ -48,17 +48,20 @@ class BarGeometryPainter<T> extends GeometryPainter<T> {
       return;
     }
 
+    final xStart = _itemWidth >= size.width ? 0.0 : (size.width - _itemWidth) / 2 ;
+    final xEnd = xStart + _itemWidth;
+
     canvas.drawRRect(
       RRect.fromRectAndCorners(
         Rect.fromPoints(
           Offset(
-            0.0,
+            xStart,
             _maxValue * _verticalMultiplier -
                 max(data.minValue, item.min ?? 0.0) * _verticalMultiplier +
                 _minValue,
           ),
           Offset(
-            _itemWidth,
+            xEnd,
             _maxValue * _verticalMultiplier -
                 _itemMaxValue * _verticalMultiplier +
                 _minValue,

--- a/lib/chart/render/geometry/painters/bar_geometry_painter.dart
+++ b/lib/chart/render/geometry/painters/bar_geometry_painter.dart
@@ -48,7 +48,7 @@ class BarGeometryPainter<T> extends GeometryPainter<T> {
       return;
     }
 
-    final xStart = _itemWidth >= size.width ? 0.0 : (size.width - _itemWidth) / 2 ;
+    final xStart = (size.width - _itemWidth) * itemOptions.startPosition;
     final xEnd = xStart + _itemWidth;
 
     canvas.drawRRect(


### PR DESCRIPTION
I noticed that the bars would not be centered in the available space if there is a maximum size set. This might be also the cause for #43 

Question is: Should this be the default behavior or should it maybe be configurable similar to the `startlinePosition` in `SparkLineDecoration` I guess that would also work well for changing the position of the bar?