### PR TITLE
Add apple charts example

### DIFF
--- a/example/lib/charts/ios_charts_screen.dart
+++ b/example/lib/charts/ios_charts_screen.dart
@@ -1,0 +1,283 @@
+import 'package:charts_painter/chart.dart';
+import 'package:example/widgets/bar_chart.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+final _batteryData = [
+  26,
+  24,
+  25,
+  45,
+  60,
+  75,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  80,
+  84,
+  88,
+  92,
+  98,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  100,
+  95,
+  92,
+  90,
+  90,
+  88,
+  88,
+  86,
+  86,
+  86,
+  86,
+  85
+];
+
+class IosChartScreen extends StatefulWidget {
+  IosChartScreen({Key? key}) : super(key: key);
+
+  @override
+  _IosChartScreenState createState() => _IosChartScreenState();
+}
+
+class _IosChartScreenState extends State<IosChartScreen> {
+  int _currentState = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(
+            'Apple battery chart',
+          ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(12.0),
+          child: Center(
+            child: SizedBox(
+              height: 180,
+              child: BarChart(
+                data: _batteryData
+                    .map((e) => BarValue<void>(e.toDouble()))
+                    .toList(),
+                height: MediaQuery.of(context).size.height * 0.18,
+                dataToValue: (BarValue value) => value.max ?? 0.0,
+                itemOptions: BarItemOptions(
+                  padding: const EdgeInsets.symmetric(horizontal: 2.0),
+                  minBarWidth: 4.0,
+                  barItemBuilder: (data) {
+                    return BarItem(
+                      radius: const BorderRadius.vertical(
+                        top: Radius.circular(24.0),
+                      ),
+                      color: CupertinoColors.systemGreen,
+                    );
+                  },
+                ),
+                backgroundDecorations: [
+                  WidgetDecoration(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    widgetDecorationBuilder:
+                        (context, state, squareWidth, squareHeight) {
+                      return Container(
+                        child: Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            Positioned.fill(
+                              child: Padding(
+                                padding:
+                                    (state.defaultMargin + state.defaultPadding)
+                                        .copyWith(bottom: 0),
+                                child: Stack(
+                                  clipBehavior: Clip.none,
+                                  children: [
+                                    // First (Smaller) green rectangle area
+                                    Positioned(
+                                      top: 2.0,
+                                      bottom: 36.0,
+                                      left: squareWidth * 2,
+                                      width: squareWidth * 4,
+                                      child: Container(
+                                        color: CupertinoColors.activeGreen
+                                            .withOpacity(0.4),
+                                      ),
+                                    ),
+                                    // Second (Bigger) green rectangle area
+                                    Positioned(
+                                      top: 2.0,
+                                      bottom: 36.0,
+                                      left: squareWidth * 20,
+                                      width: squareWidth * 20,
+                                      child: Container(
+                                        color: CupertinoColors.activeGreen
+                                            .withOpacity(0.4),
+                                      ),
+                                    ),
+                                    // Bottom battery state indicator (green)
+                                    Positioned(
+                                      bottom: 30.0,
+                                      height: 24.0,
+                                      left: squareWidth * 2,
+                                      child: Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.end,
+                                        children: [
+                                          Container(
+                                            height: 6.0,
+                                            width: squareWidth * 4,
+                                            decoration: ShapeDecoration(
+                                              shape: StadiumBorder(),
+                                              color:
+                                                  CupertinoColors.systemGreen,
+                                            ),
+                                          ),
+                                          // Indicator with pause icon
+                                          Container(
+                                            width: squareWidth * 14,
+                                            child: Stack(
+                                              clipBehavior: Clip.none,
+                                              children: [
+                                                Positioned(
+                                                  left: 0,
+                                                  right: 0,
+                                                  height: 6,
+                                                  bottom: 0,
+                                                  child: Container(
+                                                    decoration: ShapeDecoration(
+                                                      shape: StadiumBorder(),
+                                                      color: CupertinoColors
+                                                          .systemGreen
+                                                          .withOpacity(0.2),
+                                                    ),
+                                                  ),
+                                                ),
+                                                Positioned(
+                                                  left: 0,
+                                                  right: 0,
+                                                  bottom: -6,
+                                                  height: 18,
+                                                  child: Center(
+                                                    child: Container(
+                                                      width: 18,
+                                                      height: 18,
+                                                      color: Colors.white,
+                                                      child: Icon(
+                                                        Icons.pause,
+                                                        color: CupertinoColors
+                                                            .systemGreen,
+                                                        size: 20,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                )
+                                              ],
+                                            ),
+                                          ),
+                                          // Indicator with charge icon
+                                          Container(
+                                            width: squareWidth * 20,
+                                            child: Stack(
+                                              clipBehavior: Clip.none,
+                                              children: [
+                                                Positioned(
+                                                  left: 0,
+                                                  right: 0,
+                                                  height: 6,
+                                                  bottom: 0,
+                                                  child: Container(
+                                                    decoration: ShapeDecoration(
+                                                      shape: StadiumBorder(),
+                                                      color: CupertinoColors
+                                                          .systemGreen,
+                                                    ),
+                                                  ),
+                                                ),
+                                                Positioned(
+                                                  left: 0,
+                                                  right: 0,
+                                                  bottom: -6,
+                                                  height: 18,
+                                                  child: Center(
+                                                    child: Container(
+                                                      width: 18,
+                                                      height: 18,
+                                                      color: Colors.white,
+                                                      child: Icon(
+                                                        Icons
+                                                            .electric_bolt_outlined,
+                                                        color: CupertinoColors
+                                                            .systemGreen,
+                                                        size: 20,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                )
+                                              ],
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                  GridDecoration(
+                    verticalAxisStep: 12,
+                    horizontalAxisStep: 25,
+                    endWithChartVertical: false,
+                    endWithChartHorizontal: true,
+                    showHorizontalValues: true,
+                    gridWidth: 1.0,
+                    gridColor: Colors.grey.shade300,
+                    horizontalAxisValueFromValue: (index) =>
+                        index % 2 == 0 ? '${index}%' : '',
+                    horizontalValuesPadding:
+                        const EdgeInsets.only(top: 8.0, left: 4.0),
+                    verticalAxisValueFromIndex: (index) =>
+                        '${(((index / 4) + 9) % 12).toStringAsFixed(0).padLeft(2, '0').replaceAll('00', '12 A')}',
+                    textStyle: TextStyle(color: Colors.grey),
+                    verticalTextAlign: TextAlign.start,
+                    verticalValuesPadding:
+                        const EdgeInsets.only(left: 4, bottom: 18.0),
+                    showVerticalValues: true,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ));
+  }
+}

--- a/example/lib/charts/scrollable_chart_screen.dart
+++ b/example/lib/charts/scrollable_chart_screen.dart
@@ -113,7 +113,6 @@ class _ScrollableChartScreenState extends State<ScrollableChartScreen> {
               Theme.of(context).colorScheme.primaryVariant.withOpacity(0.8),
         ),
         GridDecoration(
-          endWithChart: false,
           showVerticalGrid: true,
           showHorizontalValues: _fixedAxis ? false : _showValues,
           showVerticalValues: _fixedAxis ? true : _showValues,

--- a/example/lib/charts/showcase_chart_screen.dart
+++ b/example/lib/charts/showcase_chart_screen.dart
@@ -26,7 +26,8 @@ class _ShowcaseChartScreenState extends State<ShowcaseChartScreen> {
             child: Padding(
               padding: const EdgeInsets.all(12.0),
               child: AnimatedChart<bool>(
-                  duration: Duration(milliseconds: 650), state: _chartStates[_currentState % _chartStates.length]),
+                  duration: Duration(milliseconds: 650),
+                  state: _chartStates[_currentState % _chartStates.length]),
             ),
           ),
           SizedBox(height: 48.0),
@@ -93,7 +94,8 @@ final List<ChartState<bool>> _chartStates = [
       padding: const EdgeInsets.symmetric(horizontal: 12.0),
       barItemBuilder: (data) {
         dynamic _value = data.item.value;
-        final color = (_value is bool && _value) ? Color(0xFF567EF7) : Color(0xFF5ABEF9);
+        final color =
+            (_value is bool && _value) ? Color(0xFF567EF7) : Color(0xFF5ABEF9);
         return BarItem(
           color: color,
           radius: BorderRadius.all(Radius.circular(12.0)),
@@ -103,15 +105,18 @@ final List<ChartState<bool>> _chartStates = [
     backgroundDecorations: [
       GridDecoration(
         horizontalAxisStep: 2,
-        endWithChart: true,
+        endWithChartVertical: true,
+        endWithChartHorizontal: true,
         showHorizontalValues: true,
         horizontalLegendPosition: HorizontalLegendPosition.start,
         gridColor: Colors.black26,
         dashArray: [8, 8],
         gridWidth: 1.5,
-        horizontalValuesPadding: const EdgeInsets.only(bottom: -7.0, right: 16.0),
+        horizontalValuesPadding:
+            const EdgeInsets.only(bottom: -7.0, right: 16.0),
         horizontalAxisValueFromValue: (value) => '${value}k',
-        textStyle: TextStyle(fontSize: 14.0, color: Colors.black26, fontWeight: FontWeight.w500),
+        textStyle: TextStyle(
+            fontSize: 14.0, color: Colors.black26, fontWeight: FontWeight.w500),
       ),
     ],
     foregroundDecorations: [],
@@ -151,7 +156,8 @@ final List<ChartState<bool>> _chartStates = [
     ),
     backgroundDecorations: [
       GridDecoration(
-        endWithChart: true,
+        endWithChartVertical: true,
+        endWithChartHorizontal: true,
         showHorizontalValues: true,
         showVerticalGrid: false,
         showVerticalValues: true,
@@ -159,10 +165,12 @@ final List<ChartState<bool>> _chartStates = [
         horizontalLegendPosition: HorizontalLegendPosition.start,
         gridColor: Colors.grey.shade200,
         gridWidth: 1,
-        horizontalValuesPadding: const EdgeInsets.only(bottom: -8.0, right: 8.0),
+        horizontalValuesPadding:
+            const EdgeInsets.only(bottom: -8.0, right: 8.0),
         verticalValuesPadding: const EdgeInsets.only(top: 24.0),
         horizontalAxisValueFromValue: (value) => '${value + 1}h',
-        verticalAxisValueFromIndex: (value) => ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][value],
+        verticalAxisValueFromIndex: (value) =>
+            ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][value],
         textStyle: TextStyle(fontSize: 14.0, color: Colors.black45),
       ),
     ],
@@ -192,7 +200,8 @@ final List<ChartState<bool>> _chartStates = [
     ),
     itemOptions: BarItemOptions(
       barItemBuilder: (data) {
-        return BarItem(color: [Color(0xFF5B6ACF), Color(0xFFB6CADD)][data.listKey]);
+        return BarItem(
+            color: [Color(0xFF5B6ACF), Color(0xFFB6CADD)][data.listKey]);
       },
       multiValuePadding: const EdgeInsets.symmetric(horizontal: 4.0),
       padding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -202,7 +211,8 @@ final List<ChartState<bool>> _chartStates = [
       GridDecoration(
         horizontalAxisStep: 10.0,
         showVerticalGrid: false,
-        endWithChart: true,
+        endWithChartVertical: true,
+        endWithChartHorizontal: true,
         showVerticalValues: true,
         gridColor: Colors.grey.shade400,
         gridWidth: 1,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:charts_painter/chart.dart';
 import 'package:example/chart_types.dart';
 import 'package:example/charts/bar_target_chart_screen.dart';
 import 'package:example/complex/complex_charts.dart';
+import 'package:example/showcase/ios_charts.dart';
 import 'package:example/showcase/showcase_charts.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -85,12 +86,15 @@ class ShowList extends StatelessWidget {
               child: Chart(
                 state: ChartState<void>(
                   ChartData.fromList(
-                    [2, 7, 2, 4, 7, 6, 2, 5, 4].map((e) => BubbleValue<void>(e.toDouble())).toList(),
+                    [2, 7, 2, 4, 7, 6, 2, 5, 4]
+                        .map((e) => BubbleValue<void>(e.toDouble()))
+                        .toList(),
                     axisMax: 9,
                   ),
                   itemOptions: BubbleItemOptions(
                     padding: const EdgeInsets.symmetric(horizontal: 2.0),
-                    bubbleItemBuilder: (_) => BubbleItem(color: Theme.of(context).accentColor),
+                    bubbleItemBuilder: (_) =>
+                        BubbleItem(color: Theme.of(context).accentColor),
                     maxBarWidth: 1.0,
                   ),
                   backgroundDecorations: [
@@ -109,7 +113,8 @@ class ShowList extends StatelessWidget {
             ),
           ),
           onTap: () {
-            Navigator.of(context).push<void>(MaterialPageRoute(builder: (_) => LineChartScreen()));
+            Navigator.of(context).push<void>(
+                MaterialPageRoute(builder: (_) => LineChartScreen()));
           },
         ),
         Divider(),
@@ -122,12 +127,15 @@ class ShowList extends StatelessWidget {
               child: Chart(
                 state: ChartState<void>(
                     ChartData.fromList(
-                      [1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BarValue<void>(e.toDouble())).toList(),
+                      [1, 3, 4, 2, 7, 6, 2, 5, 4]
+                          .map((e) => BarValue<void>(e.toDouble()))
+                          .toList(),
                       axisMax: 8,
                     ),
                     itemOptions: BarItemOptions(
                       padding: const EdgeInsets.symmetric(horizontal: 2.0),
-                      barItemBuilder: (_) => BarItem(color: Theme.of(context).accentColor),
+                      barItemBuilder: (_) =>
+                          BarItem(color: Theme.of(context).accentColor),
                       maxBarWidth: 4.0,
                     ),
                     backgroundDecorations: [
@@ -141,7 +149,8 @@ class ShowList extends StatelessWidget {
                       TargetLineDecoration(
                         target: 6,
                         colorOverTarget: Theme.of(context).colorScheme.error,
-                        targetLineColor: Theme.of(context).colorScheme.secondary,
+                        targetLineColor:
+                            Theme.of(context).colorScheme.secondary,
                       ),
                       BorderDecoration(
                         borderWidth: 1.5,
@@ -152,7 +161,8 @@ class ShowList extends StatelessWidget {
             ),
           ),
           onTap: () {
-            Navigator.of(context).push<void>(MaterialPageRoute(builder: (_) => BarTargetChartScreen()));
+            Navigator.of(context).push<void>(
+                MaterialPageRoute(builder: (_) => BarTargetChartScreen()));
           },
         ),
         Divider(),
@@ -176,7 +186,9 @@ class ShowList extends StatelessWidget {
               child: Chart(
                 state: ChartState<void>(
                   ChartData.fromList(
-                    [1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BarValue<void>(e.toDouble())).toList(),
+                    [1, 3, 4, 2, 7, 6, 2, 5, 4]
+                        .map((e) => BarValue<void>(e.toDouble()))
+                        .toList(),
                     axisMax: 8,
                   ),
                   itemOptions: BarItemOptions(
@@ -201,7 +213,8 @@ class ShowList extends StatelessWidget {
             ),
           ),
           onTap: () {
-            Navigator.of(context).push<void>(MaterialPageRoute(builder: (_) => ScrollableChartScreen()));
+            Navigator.of(context).push<void>(
+                MaterialPageRoute(builder: (_) => ScrollableChartScreen()));
           },
         ),
         Divider(),
@@ -218,6 +231,7 @@ class ShowList extends StatelessWidget {
         Divider(),
         ComplexCharts(),
         ShowcaseCharts(),
+        IosCharts(),
         SizedBox(
           height: 24.0,
         ),

--- a/example/lib/showcase/ios_charts.dart
+++ b/example/lib/showcase/ios_charts.dart
@@ -1,16 +1,16 @@
 import 'package:charts_painter/chart.dart';
-import 'package:example/charts/showcase_chart_screen.dart';
+import 'package:example/charts/ios_charts_screen.dart';
 import 'package:flutter/material.dart';
 
-class ShowcaseCharts extends StatelessWidget {
-  const ShowcaseCharts({Key? key}) : super(key: key);
+class IosCharts extends StatelessWidget {
+  const IosCharts({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         ListTile(
-          title: Text('Showcase charts'),
+          title: Text('iOS charts'),
           trailing: Padding(
             padding: const EdgeInsets.symmetric(vertical: 8),
             child: Container(
@@ -83,7 +83,7 @@ class ShowcaseCharts extends StatelessWidget {
           ),
           onTap: () {
             Navigator.of(context).push<void>(
-                MaterialPageRoute(builder: (_) => ShowcaseChartScreen()));
+                MaterialPageRoute(builder: (_) => IosChartScreen()));
           },
         ),
         Divider(),

--- a/lib/chart/model/chart_state.dart
+++ b/lib/chart/model/chart_state.dart
@@ -107,12 +107,16 @@ class ChartState<T> {
   /// Decorations for chart foreground, they are drawn last, and the go above items
   final List<DecorationPainter> foregroundDecorations;
 
-  /// Margin of chart drawing area where items are drawn. This is so decorations
-  /// can be placed outside of the chart drawing area without actually scaling the chart.
+  /// Margin of chart drawing area where items are drawn.
+  ///
+  /// Whole chart and all items will move with margin
   EdgeInsets defaultMargin;
 
   /// Padding is used for decorations that want other decorations to be drawn on them.
-  /// Unlike [defaultMargin] decorations can draw inside the padding area.
+  /// Unlike [defaultMargin] some decorations don't need to respect padding.
+  /// Sometimes decorations paint over this padding.
+  ///
+  /// Whole chart and all items will move with margin
   EdgeInsets defaultPadding;
 
   /// Get all decorations. This will return list of [backgroundDecorations] and [foregroundDecorations] as one list.
@@ -189,25 +193,28 @@ class ChartState<T> {
   /// [ItemOptions].
   ///
   /// If you need more customization of the individual chart items see [_widgetItemRenderer]
-  static ChartDataRendererFactory<T?> _defaultItemRenderer<T>(ItemOptions itemOptions) {
+  static ChartDataRendererFactory<T?> _defaultItemRenderer<T>(
+      ItemOptions itemOptions) {
     return (chartState) {
       return ChartLinearDataRenderer<T?>(
-        chartState,
-        chartState.data.items
-            .mapIndexed(
-              (lineKey, items) => items
-                  .mapIndexed((itemKey, item) => LeafChartItemRenderer(
-                        item,
-                        chartState.data,
-                        itemOptions,
-                        itemKey: itemKey,
-                        listKey: lineKey,
-                        drawDataItem: itemOptions.itemBuilder(ItemBuilderData<T?>(item, itemKey, lineKey)) as DrawDataItem,
-                      ))
-                  .toList(),
-            )
-            .expand((element) => element)
-            .toList());
+          chartState,
+          chartState.data.items
+              .mapIndexed(
+                (lineKey, items) => items
+                    .mapIndexed((itemKey, item) => LeafChartItemRenderer(
+                          item,
+                          chartState.data,
+                          itemOptions,
+                          itemKey: itemKey,
+                          listKey: lineKey,
+                          drawDataItem: itemOptions.itemBuilder(
+                                  ItemBuilderData<T?>(item, itemKey, lineKey))
+                              as DrawDataItem,
+                        ))
+                    .toList(),
+              )
+              .expand((element) => element)
+              .toList());
     };
   }
 
@@ -227,7 +234,8 @@ class ChartState<T> {
                         chartState.data,
                         itemOptions,
                         arrayKey: lineKey,
-                        child: itemOptions.widgetItemBuilder(ItemBuilderData<T?>(e, itemKey, lineKey)),
+                        child: itemOptions.widgetItemBuilder(
+                            ItemBuilderData<T?>(e, itemKey, lineKey)),
                       ),
                     )
                     .toList();
@@ -237,4 +245,3 @@ class ChartState<T> {
             .toList());
   }
 }
-

--- a/lib/chart/render/decorations/grid_decoration.dart
+++ b/lib/chart/render/decorations/grid_decoration.dart
@@ -8,31 +8,33 @@ class GridDecoration extends DecorationPainter {
   ///
   /// Grid decoration is just merge of [HorizontalAxisDecoration] and [VerticalAxisDecoration]
   GridDecoration({
-    this.showHorizontalValues = false,
-    this.showVerticalValues = false,
-    bool endWithChart = false,
-    this.horizontalTextAlign = TextAlign.end,
-    this.showTopHorizontalValue = false,
-    this.verticalTextAlign = TextAlign.center,
-    this.showVerticalGrid = true,
-    this.showHorizontalGrid = true,
-    this.verticalValuesPadding,
-    this.horizontalValuesPadding,
-    this.horizontalAxisUnit,
-    this.verticalAxisValueFromIndex = defaultAxisValue,
-    this.horizontalAxisValueFromValue = defaultAxisValue,
-    this.gridColor = Colors.grey,
-    this.gridWidth = 1.0,
-    this.dashArray,
-    this.verticalAxisStep = 1,
-    this.horizontalAxisStep = 1,
-    this.textScale = 1.0,
-    this.horizontalLegendPosition = HorizontalLegendPosition.end,
-    this.verticalLegendPosition = VerticalLegendPosition.bottom,
-    this.showHorizontalLineForValue,
-    this.textStyle,
-  })  : _endWithChart = endWithChart ? 1.0 : 0.0,
-        assert(
+    bool showHorizontalValues = false,
+    bool showVerticalValues = false,
+    bool endWithChartHorizontal = false,
+    bool endWithChartVertical = false,
+    TextAlign horizontalTextAlign = TextAlign.end,
+    bool showTopHorizontalValue = false,
+    TextAlign verticalTextAlign = TextAlign.center,
+    bool showVerticalGrid = true,
+    bool showHorizontalGrid = true,
+    EdgeInsets? verticalValuesPadding,
+    EdgeInsets? horizontalValuesPadding,
+    String? horizontalAxisUnit,
+    AxisValueFromValue verticalAxisValueFromIndex = defaultAxisValue,
+    AxisValueFromValue horizontalAxisValueFromValue = defaultAxisValue,
+    Color gridColor = Colors.grey,
+    double gridWidth = 1.0,
+    List<double>? dashArray,
+    double verticalAxisStep = 1.0,
+    double horizontalAxisStep = 1.0,
+    double textScale = 1.0,
+    HorizontalLegendPosition horizontalLegendPosition =
+        HorizontalLegendPosition.end,
+    VerticalLegendPosition verticalLegendPosition =
+        VerticalLegendPosition.bottom,
+    ShowLineForValue? showHorizontalLineForValue,
+    TextStyle? textStyle,
+  }) : assert(
             textStyle != null ||
                 !(showHorizontalValues ||
                     showTopHorizontalValue ||
@@ -40,7 +42,7 @@ class GridDecoration extends DecorationPainter {
             'Need to provide text style for values to be visible!') {
     _horizontalAxisDecoration = HorizontalAxisDecoration(
       showValues: showHorizontalValues,
-      endWithChart: endWithChart,
+      endWithChart: endWithChartHorizontal,
       showLines: showHorizontalGrid,
       valuesAlign: horizontalTextAlign,
       valuesPadding: horizontalValuesPadding,
@@ -60,7 +62,7 @@ class GridDecoration extends DecorationPainter {
       showValues: showVerticalValues,
       valuesAlign: verticalTextAlign,
       showLines: showVerticalGrid,
-      endWithChart: endWithChart,
+      endWithChart: endWithChartVertical,
       lineColor: gridColor,
       dashArray: dashArray,
       valueFromIndex: verticalAxisValueFromIndex,
@@ -73,156 +75,13 @@ class GridDecoration extends DecorationPainter {
   }
 
   GridDecoration._lerp({
-    this.showHorizontalValues = false,
-    this.showVerticalValues = false,
-    double endWithChart = 0.0,
-    this.horizontalTextAlign = TextAlign.end,
-    this.showTopHorizontalValue = false,
-    this.verticalTextAlign = TextAlign.center,
-    this.showVerticalGrid = true,
-    this.showHorizontalGrid = true,
-    this.verticalValuesPadding,
-    this.horizontalValuesPadding,
-    this.horizontalAxisUnit,
-    this.verticalAxisValueFromIndex = defaultAxisValue,
-    this.horizontalAxisValueFromValue = defaultAxisValue,
-    this.gridColor = Colors.grey,
-    this.gridWidth = 1.0,
-    this.verticalAxisStep = 1,
-    this.horizontalAxisStep = 1,
-    this.textScale = 1.5,
-    this.dashArray,
-    this.showHorizontalLineForValue,
-    this.horizontalLegendPosition = HorizontalLegendPosition.end,
-    this.verticalLegendPosition = VerticalLegendPosition.bottom,
-    this.textStyle,
-  })  : _endWithChart = endWithChart,
-        assert(
-            textStyle != null ||
-                !(showHorizontalValues ||
-                    showTopHorizontalValue ||
-                    showVerticalValues),
-            'Need to provide text style for values to be visible!') {
-    _horizontalAxisDecoration = HorizontalAxisDecoration._lerp(
-      showValues: showHorizontalValues,
-      endWithChart: _endWithChart,
-      valuesAlign: horizontalTextAlign,
-      showTopValue: showTopHorizontalValue,
-      showLines: showHorizontalGrid,
-      horizontalAxisUnit: horizontalAxisUnit,
-      valuesPadding: horizontalValuesPadding,
-      lineColor: gridColor,
-      dashArray: dashArray,
-      textScale: textScale,
-      showLineForValue: showHorizontalLineForValue,
-      axisValue: horizontalAxisValueFromValue,
-      lineWidth: gridWidth,
-      axisStep: horizontalAxisStep,
-      legendFontStyle: textStyle,
-      legendPosition: horizontalLegendPosition,
-    );
-    _verticalAxisDecoration = VerticalAxisDecoration._lerp(
-      showValues: showVerticalValues,
-      valuesAlign: verticalTextAlign,
-      showLines: showVerticalGrid,
-      endWithChart: _endWithChart,
-      lineColor: gridColor,
-      dashArray: dashArray,
-      valueFromIndex: verticalAxisValueFromIndex,
-      valuesPadding: verticalValuesPadding,
-      lineWidth: gridWidth,
-      legendPosition: verticalLegendPosition,
-      axisStep: verticalAxisStep,
-      legendFontStyle: textStyle,
-    );
-  }
-
-  /// Should grid show horizontal axis values.
-  ///
-  /// Need to provide [textStyle] if this is set to true
-  final bool showHorizontalValues;
-
-  /// Should grid show vertical axis values
-  ///
-  /// Need to provide [textStyle] if this is set to true
-  final bool showVerticalValues;
-
-  /// This decoration can continue beyond padding set by [ChartState]
-  /// setting this to true will stop drawing on padding, and will end
-  /// at same place where the chart will end
-  ///
-  /// This does not apply to axis legend text, text can still be shown on the padding part
-  bool get endWithChart => _endWithChart > 0.5;
-  final double _endWithChart;
-
-  /// Align horizontal legend text
-  final TextAlign horizontalTextAlign;
-
-  /// Align vertical legend text
-  final TextAlign verticalTextAlign;
-
-  /// Text style for legends, same style is used for both [HorizontalAxisDecoration] and [VerticalAxisDecoration], if
-  /// both [showHorizontalValues] and [showVerticalValues] are set to true.
-  final TextStyle? textStyle;
-
-  /// Padding for horizontal values in axis legend
-  final EdgeInsets? horizontalValuesPadding;
-
-  /// Padding for vertical values in axis legend
-  final EdgeInsets? verticalValuesPadding;
-
-  /// Should top horizontal value be shown? This will increase padding such that
-  /// text fits above the chart and adds top most value on horizontal scale.
-  final bool showTopHorizontalValue;
-
-  /// Hide or show vertical lines on the grid
-  final bool showVerticalGrid;
-
-  /// Hide or show horizontal lines on the grid
-  final bool showHorizontalGrid;
-
-  /// Label that is shown at the end of the chart on horizontal axis.
-  /// This is usually to show measure unit used for axis
-  final String? horizontalAxisUnit;
-
-  /// Dash array pattern for creating dashed grid
-  final List<double>? dashArray;
-
-  /// Position of horizontal legend
-  /// Default: [HorizontalLegendPosition.end]
-  /// Can be [HorizontalLegendPosition.start] or [HorizontalLegendPosition.end]
-  final HorizontalLegendPosition horizontalLegendPosition;
-
-  /// Position of vertical legend
-  /// Default: [VerticalLegendPosition.bottom]
-  /// Can be [VerticalLegendPosition.bottom] or [VerticalLegendPosition.top]
-  final VerticalLegendPosition verticalLegendPosition;
+    required HorizontalAxisDecoration horizontalAxisDecoration,
+    required VerticalAxisDecoration verticalAxisDecoration,
+  })  : _horizontalAxisDecoration = horizontalAxisDecoration,
+        _verticalAxisDecoration = verticalAxisDecoration;
 
   late HorizontalAxisDecoration _horizontalAxisDecoration;
   late VerticalAxisDecoration _verticalAxisDecoration;
-
-  /// Generate vertical axis legend from item index
-  final AxisValueFromIndex verticalAxisValueFromIndex;
-
-  /// Generate horizontal axis legend from value steps
-  final AxisValueFromValue horizontalAxisValueFromValue;
-
-  /// Show horizontal line for current value. Return true if you want to show the line.
-  final ShowLineForValue? showHorizontalLineForValue;
-
-  /// Change grid color
-  final Color gridColor;
-
-  /// Change grid line width
-  final double gridWidth;
-
-  final double textScale;
-
-  /// Change step for y axis (1 by default) used in [GridDecoration], [VerticalAxisDecoration] and [HorizontalAxisDecoration]
-  final double verticalAxisStep;
-
-  /// Change step for x axis (1 by default) used in [GridDecoration], [VerticalAxisDecoration] and [HorizontalAxisDecoration]
-  final double horizontalAxisStep;
 
   @override
   void draw(Canvas canvas, Size size, ChartState state) {
@@ -232,12 +91,29 @@ class GridDecoration extends DecorationPainter {
 
   @override
   Size layoutSize(BoxConstraints constraints, ChartState state) {
-    return constraints.deflate(state.defaultMargin).biggest;
+    return constraints
+        .deflate(state.defaultMargin +
+            state.defaultPadding.copyWith(
+              left: _horizontalAxisDecoration._endWithChart *
+                  state.defaultPadding.left,
+              right: _horizontalAxisDecoration._endWithChart *
+                  state.defaultPadding.right,
+              top: _verticalAxisDecoration._endWithChart *
+                  state.defaultPadding.top,
+              bottom: _verticalAxisDecoration._endWithChart *
+                  state.defaultPadding.bottom,
+            ))
+        .biggest;
   }
 
   @override
   Offset applyPaintTransform(ChartState state, Size size) {
-    return Offset(state.defaultMargin.left, state.defaultMargin.top);
+    return Offset(
+        state.defaultMargin.left +
+            (_horizontalAxisDecoration._endWithChart *
+                state.defaultPadding.left),
+        state.defaultMargin.top +
+            (_verticalAxisDecoration._endWithChart * state.defaultPadding.top));
   }
 
   @override
@@ -262,53 +138,10 @@ class GridDecoration extends DecorationPainter {
   DecorationPainter animateTo(DecorationPainter endValue, double t) {
     if (endValue is GridDecoration) {
       return GridDecoration._lerp(
-        showHorizontalValues:
-            t < 0.5 ? showHorizontalValues : endValue.showHorizontalValues,
-        showVerticalValues:
-            t < 0.5 ? showVerticalValues : endValue.showVerticalValues,
-        endWithChart: lerpDouble(_endWithChart, endValue._endWithChart, t) ??
-            endValue._endWithChart,
-        horizontalTextAlign:
-            t < 0.5 ? horizontalTextAlign : endValue.horizontalTextAlign,
-        showTopHorizontalValue:
-            t < 0.5 ? showTopHorizontalValue : endValue.showTopHorizontalValue,
-        verticalTextAlign:
-            t < 0.5 ? verticalTextAlign : endValue.verticalTextAlign,
-        showVerticalGrid:
-            t < 0.5 ? showVerticalGrid : endValue.showVerticalGrid,
-        showHorizontalGrid:
-            t < 0.5 ? showHorizontalGrid : endValue.showHorizontalGrid,
-        horizontalAxisUnit:
-            t < 0.5 ? horizontalAxisUnit : endValue.horizontalAxisUnit,
-        verticalAxisValueFromIndex: t < 0.5
-            ? verticalAxisValueFromIndex
-            : endValue.verticalAxisValueFromIndex,
-        horizontalAxisValueFromValue: t < 0.5
-            ? horizontalAxisValueFromValue
-            : endValue.horizontalAxisValueFromValue,
-        horizontalLegendPosition: t < 0.5
-            ? horizontalLegendPosition
-            : endValue.horizontalLegendPosition,
-        verticalLegendPosition:
-            t < 0.5 ? verticalLegendPosition : endValue.verticalLegendPosition,
-        gridColor:
-            Color.lerp(gridColor, endValue.gridColor, t) ?? endValue.gridColor,
-        dashArray: t < 0.5 ? dashArray : endValue.dashArray,
-        gridWidth:
-            lerpDouble(gridWidth, endValue.gridWidth, t) ?? endValue.gridWidth,
-        verticalAxisStep:
-            lerpDouble(verticalAxisStep, endValue.verticalAxisStep, t) ??
-                endValue.verticalAxisStep,
-        textScale:
-            lerpDouble(textScale, endValue.textScale, t) ?? endValue.textScale,
-        horizontalAxisStep:
-            lerpDouble(horizontalAxisStep, endValue.horizontalAxisStep, t) ??
-                endValue.horizontalAxisStep,
-        verticalValuesPadding: EdgeInsets.lerp(
-            verticalValuesPadding, endValue.verticalValuesPadding, t),
-        horizontalValuesPadding: EdgeInsets.lerp(
-            horizontalValuesPadding, endValue.horizontalValuesPadding, t),
-        textStyle: TextStyle.lerp(textStyle, endValue.textStyle, t),
+        horizontalAxisDecoration: _horizontalAxisDecoration.animateTo(
+            endValue._horizontalAxisDecoration, t),
+        verticalAxisDecoration: _verticalAxisDecoration.animateTo(
+            endValue._verticalAxisDecoration, t),
       );
     }
 

--- a/lib/chart/render/decorations/horizontal_axis_decoration.dart
+++ b/lib/chart/render/decorations/horizontal_axis_decoration.dart
@@ -125,13 +125,20 @@ class HorizontalAxisDecoration extends DecorationPainter {
   String? _longestText;
 
   @override
-  Offset applyPaintTransform(ChartState state, Size size) {
-    return Offset(state.defaultMargin.left, state.defaultMargin.top);
+  Size layoutSize(BoxConstraints constraints, ChartState state) {
+    return constraints
+        .deflate(state.defaultMargin +
+            state.defaultPadding.copyWith(
+                left: _endWithChart * state.defaultPadding.left,
+                right: _endWithChart * state.defaultPadding.right))
+        .biggest;
   }
 
   @override
-  Size layoutSize(BoxConstraints constraints, ChartState state) {
-    return constraints.deflate(state.defaultMargin).biggest;
+  Offset applyPaintTransform(ChartState state, Size size) {
+    return Offset(
+        state.defaultMargin.left + (_endWithChart * state.defaultPadding.left),
+        state.defaultMargin.top + state.defaultPadding.top);
   }
 
   @override
@@ -164,12 +171,18 @@ class HorizontalAxisDecoration extends DecorationPainter {
       final _defaultValue = (axisStep * i + state.data.minValue).toInt();
 
       final _isPositionStart = legendPosition == HorizontalLegendPosition.start;
-      final _startLine = _isPositionStart ? -((state.defaultMargin.left) * (1 - _endWithChart)) : 0.0;
-      final _endLine = _isPositionStart ? 0.0 : ((state.defaultMargin.right) * (1 - _endWithChart));
+      final _startLine = _isPositionStart
+          ? -((state.defaultMargin.left) * (1 - _endWithChart))
+          : 0.0;
+      final _endLine = _isPositionStart
+          ? 0.0
+          : ((state.defaultMargin.right) * (1 - _endWithChart));
 
       if (showLineForValue?.call(_defaultValue) ?? showLines) {
-        gridPath.moveTo(_startLine, size.height - (lineWidth / 2 + axisStep * i * scale));
-        gridPath.lineTo((size.width + _endLine), size.height - (lineWidth / 2 + axisStep * i * scale));
+        gridPath.moveTo(
+            _startLine, size.height - (lineWidth / 2 + axisStep * i * scale));
+        gridPath.lineTo((size.width + _endLine),
+            size.height - (lineWidth / 2 + axisStep * i * scale));
       }
 
       if (!showValues) {
@@ -189,15 +202,23 @@ class HorizontalAxisDecoration extends DecorationPainter {
         continue;
       }
 
-      final _textPainter = _getTextPainter(_text, size: asFixedDecoration ? size : null);
+      final _textPainter =
+          _getTextPainter(_text, size: asFixedDecoration ? size : null);
 
       final _positionEnd = size.width + (valuesPadding?.left ?? 0);
-      final _positionStart = -((valuesPadding?.right ?? 0.0) + _getTextPainter(_longestText).width);
+      final _positionStart = -((valuesPadding?.right ?? 0.0) +
+          _getTextPainter(_longestText).width);
 
       _textPainter.paint(
           canvas,
-          Offset(legendPosition == HorizontalLegendPosition.end ? _positionEnd : _positionStart,
-              _height - axisStep * i * scale - (_textPainter.height + (valuesPadding?.bottom ?? 0.0))));
+          Offset(
+              legendPosition == HorizontalLegendPosition.end
+                  ? _positionEnd
+                  : _positionStart,
+              _height -
+                  axisStep * i * scale -
+                  (_textPainter.height + (valuesPadding?.bottom ?? 0.0)) +
+                  (valuesPadding?.top ?? 0.0)));
     }
 
     if (dashArray != null) {
@@ -216,7 +237,8 @@ class HorizontalAxisDecoration extends DecorationPainter {
       return;
     }
 
-    final _textPainter = _getTextPainter(horizontalAxisUnit, size: asFixedDecoration ? size : null);
+    final _textPainter = _getTextPainter(horizontalAxisUnit,
+        size: asFixedDecoration ? size : null);
 
     _textPainter.paint(canvas, Offset.zero);
   }
@@ -247,7 +269,9 @@ class HorizontalAxisDecoration extends DecorationPainter {
     final _width = (_painter.width + (valuesPadding?.horizontal ?? 0));
 
     return EdgeInsets.only(
-      top: showTopValue ? (_painter.height + (valuesPadding?.vertical ?? 0)) : 0.0,
+      top: showTopValue
+          ? (_painter.height + (valuesPadding?.vertical ?? 0))
+          : 0.0,
       right: _isEnd ? _width : 0.0,
       left: _isEnd ? 0.0 : _width,
     );
@@ -258,21 +282,30 @@ class HorizontalAxisDecoration extends DecorationPainter {
     if (endValue is HorizontalAxisDecoration) {
       return HorizontalAxisDecoration._lerp(
         showValues: t < 0.5 ? showValues : endValue.showValues,
-        endWithChart: lerpDouble(_endWithChart, endValue._endWithChart, t) ?? endValue._endWithChart,
+        endWithChart: lerpDouble(_endWithChart, endValue._endWithChart, t) ??
+            endValue._endWithChart,
         showTopValue: t < 0.5 ? showTopValue : endValue.showTopValue,
         valuesAlign: t < 0.5 ? valuesAlign : endValue.valuesAlign,
-        valuesPadding: EdgeInsets.lerp(valuesPadding, endValue.valuesPadding, t),
-        lineColor: Color.lerp(lineColor, endValue.lineColor, t) ?? endValue.lineColor,
-        lineWidth: lerpDouble(lineWidth, endValue.lineWidth, t) ?? endValue.lineWidth,
+        valuesPadding:
+            EdgeInsets.lerp(valuesPadding, endValue.valuesPadding, t),
+        lineColor:
+            Color.lerp(lineColor, endValue.lineColor, t) ?? endValue.lineColor,
+        lineWidth:
+            lerpDouble(lineWidth, endValue.lineWidth, t) ?? endValue.lineWidth,
         dashArray: t < 0.5 ? dashArray : endValue.dashArray,
-        axisStep: lerpDouble(axisStep, endValue.axisStep, t) ?? endValue.axisStep,
-        textScale: lerpDouble(textScale, endValue.textScale, t) ?? endValue.textScale,
-        legendFontStyle: TextStyle.lerp(legendFontStyle, endValue.legendFontStyle, t),
-        horizontalAxisUnit: t > 0.5 ? endValue.horizontalAxisUnit : horizontalAxisUnit,
+        axisStep:
+            lerpDouble(axisStep, endValue.axisStep, t) ?? endValue.axisStep,
+        textScale:
+            lerpDouble(textScale, endValue.textScale, t) ?? endValue.textScale,
+        legendFontStyle:
+            TextStyle.lerp(legendFontStyle, endValue.legendFontStyle, t),
+        horizontalAxisUnit:
+            t > 0.5 ? endValue.horizontalAxisUnit : horizontalAxisUnit,
         legendPosition: t > 0.5 ? endValue.legendPosition : legendPosition,
         axisValue: t > 0.5 ? endValue.axisValue : axisValue,
         showLines: t > 0.5 ? endValue.showLines : showLines,
-        asFixedDecoration: t > 0.5 ? endValue.asFixedDecoration : asFixedDecoration,
+        asFixedDecoration:
+            t > 0.5 ? endValue.asFixedDecoration : asFixedDecoration,
       );
     }
 

--- a/lib/chart/render/decorations/target_decoration.dart
+++ b/lib/chart/render/decorations/target_decoration.dart
@@ -1,14 +1,19 @@
 part of charts_painter;
 
 /// Check iv item is inside the target
-bool _isInTarget(double? max, {double? min, double? targetMin, double? targetMax, bool inclusive = true}) {
+bool _isInTarget(double? max,
+    {double? min,
+    double? targetMin,
+    double? targetMax,
+    bool inclusive = true}) {
   if (targetMin == null && targetMax == null) {
     return true;
   }
 
   final _min = min ?? max;
 
-  if ((targetMin != null && _min! <= targetMin) || (targetMax != null && max! >= targetMax)) {
+  if ((targetMin != null && _min! <= targetMin) ||
+      (targetMax != null && max! >= targetMax)) {
     // Check if target is inclusive, don't show error color in that case
     if (inclusive && (_min == targetMin || max == targetMax)) {
       return true;
@@ -20,10 +25,14 @@ bool _isInTarget(double? max, {double? min, double? targetMin, double? targetMax
   return true;
 }
 
-Color _getColorForTarget(
-    Color color, Color? colorOverTarget, bool isTargetInclusive, double? targetMin, double? targetMax, double? max,
+Color _getColorForTarget(Color color, Color? colorOverTarget,
+    bool isTargetInclusive, double? targetMin, double? targetMax, double? max,
     [double? min]) {
-  return _isInTarget(max, min: min, targetMax: targetMax, targetMin: targetMin, inclusive: isTargetInclusive)
+  return _isInTarget(max,
+          min: min,
+          targetMax: targetMax,
+          targetMin: targetMin,
+          inclusive: isTargetInclusive)
       ? color
       : (colorOverTarget ?? color);
 }
@@ -75,22 +84,31 @@ class TargetLineDecoration extends DecorationPainter {
   /// Pass this to [ItemOptions.colorForValue] and chart will update item colors
   /// based on target line
   Color getTargetItemColor(Color defaultColor, ChartItem item) =>
-      _getColorForTarget(defaultColor, colorOverTarget, isTargetInclusive, target, null, item.max, item.min);
+      _getColorForTarget(defaultColor, colorOverTarget, isTargetInclusive,
+          target, null, item.max, item.min);
 
   @override
   Offset applyPaintTransform(ChartState state, Size size) {
-    final _size = (state.defaultPadding + state.defaultMargin).deflateSize(size);
+    final _size =
+        (state.defaultPadding + state.defaultMargin).deflateSize(size);
     final _maxValue = state.data.maxValue - state.data.minValue;
     final scale = _size.height / _maxValue;
     final _minValue = state.data.minValue * scale;
 
-    return Offset(state.defaultMargin.left,
-        (_size.height - (lineWidth / 2)) - scale * (target ?? 0) + _minValue + state.defaultMargin.top);
+    return Offset(
+        state.defaultMargin.left,
+        (_size.height - (lineWidth / 2)) -
+            scale * (target ?? 0) +
+            _minValue +
+            state.defaultMargin.top);
   }
 
   @override
   Size layoutSize(BoxConstraints constraints, ChartState state) {
-    return Size((constraints.maxWidth - (state.defaultPadding.horizontal + state.defaultMargin.horizontal)), lineWidth);
+    return Size(
+        (constraints.maxWidth -
+            (state.defaultPadding.horizontal + state.defaultMargin.horizontal)),
+        lineWidth);
   }
 
   @override
@@ -121,11 +139,13 @@ class TargetLineDecoration extends DecorationPainter {
   TargetLineDecoration animateTo(DecorationPainter endValue, double t) {
     if (endValue is TargetLineDecoration) {
       return TargetLineDecoration(
-        targetLineColor: Color.lerp(targetLineColor, endValue.targetLineColor, t),
+        targetLineColor:
+            Color.lerp(targetLineColor, endValue.targetLineColor, t),
         lineWidth: lerpDouble(lineWidth, endValue.lineWidth, t) ?? 2.0,
         dashArray: t < 0.5 ? dashArray : endValue.dashArray,
         target: lerpDouble(target, endValue.target, t),
-        colorOverTarget: Color.lerp(colorOverTarget, endValue.colorOverTarget, t),
+        colorOverTarget:
+            Color.lerp(colorOverTarget, endValue.colorOverTarget, t),
       );
     }
 
@@ -152,7 +172,8 @@ class TargetAreaDecoration extends DecorationPainter {
     this.areaPadding = EdgeInsets.zero,
     this.targetAreaRadius,
     this.targetAreaFillColor,
-  }) : assert(areaPadding.vertical == 0, 'Vertical padding cannot be applied here!');
+  }) : assert(areaPadding.vertical == 0,
+            'Vertical padding cannot be applied here!');
 
   /// Dash pattern for the line, if left empty line will be solid
   final List<double>? dashArray;
@@ -191,11 +212,13 @@ class TargetAreaDecoration extends DecorationPainter {
   /// Pass this to [ItemOptions.colorForValue] and chart will update item colors
   /// based on target area
   Color getTargetItemColor(Color defaultColor, ChartItem item) =>
-      _getColorForTarget(defaultColor, colorOverTarget, isTargetInclusive, targetMin, targetMax, item.max, item.min);
+      _getColorForTarget(defaultColor, colorOverTarget, isTargetInclusive,
+          targetMin, targetMax, item.max, item.min);
 
   @override
   Size layoutSize(BoxConstraints constraints, ChartState state) {
-    final _size = (state.defaultPadding + state.defaultMargin).deflateSize(constraints.biggest);
+    final _size = (state.defaultPadding + state.defaultMargin)
+        .deflateSize(constraints.biggest);
     final _maxValue = state.data.maxValue - state.data.minValue;
     final scale = _size.height / _maxValue;
     final _minValue = state.data.minValue * scale;
@@ -208,13 +231,19 @@ class TargetAreaDecoration extends DecorationPainter {
 
   @override
   Offset applyPaintTransform(ChartState state, Size size) {
-    final _size = (state.defaultPadding + state.defaultMargin).deflateSize(size);
+    final _size =
+        (state.defaultPadding + state.defaultMargin).deflateSize(size);
     final _maxValue = state.data.maxValue - state.data.minValue;
     final scale = _size.height / _maxValue;
     final _minValue = state.data.minValue * scale;
 
     return Offset(
-        areaPadding.left, _size.height - scale * targetMax + _minValue + state.defaultMargin.top);
+        areaPadding.left,
+        _size.height -
+            scale * targetMax +
+            _minValue +
+            state.defaultMargin.top +
+            state.defaultPadding.top);
   }
 
   @override
@@ -273,15 +302,24 @@ class TargetAreaDecoration extends DecorationPainter {
   TargetAreaDecoration animateTo(DecorationPainter endValue, double t) {
     if (endValue is TargetAreaDecoration) {
       return TargetAreaDecoration(
-        targetLineColor: Color.lerp(targetLineColor, endValue.targetLineColor, t) ?? endValue.targetLineColor,
-        lineWidth: lerpDouble(lineWidth, endValue.lineWidth, t) ?? endValue.lineWidth,
+        targetLineColor:
+            Color.lerp(targetLineColor, endValue.targetLineColor, t) ??
+                endValue.targetLineColor,
+        lineWidth:
+            lerpDouble(lineWidth, endValue.lineWidth, t) ?? endValue.lineWidth,
         dashArray: t < 0.5 ? dashArray : endValue.dashArray,
-        targetAreaFillColor: Color.lerp(targetAreaFillColor, endValue.targetAreaFillColor, t),
-        targetAreaRadius: BorderRadius.lerp(targetAreaRadius, endValue.targetAreaRadius, t),
+        targetAreaFillColor:
+            Color.lerp(targetAreaFillColor, endValue.targetAreaFillColor, t),
+        targetAreaRadius:
+            BorderRadius.lerp(targetAreaRadius, endValue.targetAreaRadius, t),
         areaPadding: EdgeInsets.lerp(areaPadding, endValue.areaPadding, t)!,
-        targetMin: lerpDouble(targetMin, endValue.targetMin, t) ?? endValue.targetMin,
-        targetMax: lerpDouble(targetMax, endValue.targetMax, t) ?? endValue.targetMax,
-        colorOverTarget: Color.lerp(colorOverTarget, endValue.colorOverTarget, t) ?? endValue.colorOverTarget,
+        targetMin:
+            lerpDouble(targetMin, endValue.targetMin, t) ?? endValue.targetMin,
+        targetMax:
+            lerpDouble(targetMax, endValue.targetMax, t) ?? endValue.targetMax,
+        colorOverTarget:
+            Color.lerp(colorOverTarget, endValue.colorOverTarget, t) ??
+                endValue.colorOverTarget,
       );
     }
 

--- a/lib/chart/render/decorations/vertical_axis_decoration.dart
+++ b/lib/chart/render/decorations/vertical_axis_decoration.dart
@@ -97,12 +97,19 @@ class VerticalAxisDecoration extends DecorationPainter {
 
   @override
   Size layoutSize(BoxConstraints constraints, ChartState state) {
-    return constraints.deflate(state.defaultMargin).biggest;
+    return constraints
+        .deflate(state.defaultMargin +
+            state.defaultPadding.copyWith(
+              top: _endWithChart * state.defaultPadding.top,
+              bottom: _endWithChart * state.defaultPadding.bottom,
+            ))
+        .biggest;
   }
 
   @override
   Offset applyPaintTransform(ChartState state, Size size) {
-    return Offset(state.defaultMargin.left, state.defaultMargin.top);
+    return Offset(state.defaultMargin.left + state.defaultPadding.left,
+        state.defaultMargin.top + (_endWithChart * state.defaultPadding.top));
   }
 
   @override
@@ -120,11 +127,13 @@ class VerticalAxisDecoration extends DecorationPainter {
     for (var i = 0; i <= _listSize / axisStep; i++) {
       if (showLines) {
         final _showValuesTop = legendPosition == VerticalLegendPosition.top
-            ? -(marginNeeded().top * (1 - _endWithChart))
+            ? -((state.defaultMargin - marginNeeded()).top *
+                (1 - _endWithChart))
             : 0.0;
         final _showValuesBottom = size.height +
             (legendPosition == VerticalLegendPosition.bottom
-                ? (marginNeeded().vertical * (1 - _endWithChart))
+                ? ((state.defaultMargin - marginNeeded()).bottom *
+                    (1 - _endWithChart))
                 : 0.0);
 
         gridPath.moveTo(
@@ -171,8 +180,9 @@ class VerticalAxisDecoration extends DecorationPainter {
                 _itemWidth * i * axisStep +
                 (valuesPadding?.left ?? 0.0),
             legendPosition == VerticalLegendPosition.top
-                ? -(valuesPadding?.top ?? 0.0) - _textPainter.height
-                : size.height + (valuesPadding?.top ?? 0.0)),
+                ? (-(valuesPadding?.top ?? 0.0) - _textPainter.height)
+                : (((state.defaultMargin).inflateSize(size)).height -
+                    (valuesPadding?.vertical ?? 0.0))),
       );
     }
 

--- a/lib/chart/render/decorations/widget_decoration.dart
+++ b/lib/chart/render/decorations/widget_decoration.dart
@@ -42,10 +42,13 @@ class WidgetDecoration extends DecorationPainter {
   /// Constructor for selected item decoration
   WidgetDecoration({
     required this.widgetDecorationBuilder,
+    this.margin = EdgeInsets.zero,
   });
 
   /// Builder for widget decoration
   final WidgetDecorationBuilder widgetDecorationBuilder;
+
+  final EdgeInsets margin;
 
   @override
   Widget getRenderer(ChartState state) {
@@ -56,7 +59,7 @@ class WidgetDecoration extends DecorationPainter {
         builder: (context, constraints) {
           // Get all the data we need to draw the decoration and pass to the builder
           // This will ensure that we have right data in the builder and that we can show decoration to scale.
-          final _size = (state.defaultMargin).deflateSize(constraints.biggest);
+          final _size = (state.defaultMargin + state.defaultPadding).deflateSize(constraints.biggest);
           final _listSize = state.data.listSize;
           final _itemWidth = _size.width / _listSize;
 
@@ -74,10 +77,16 @@ class WidgetDecoration extends DecorationPainter {
     if (endValue is WidgetDecoration) {
       return WidgetDecoration(
         widgetDecorationBuilder: t > 0.5 ? endValue.widgetDecorationBuilder : widgetDecorationBuilder,
+        margin: EdgeInsets.lerp(margin, endValue.margin, t) ?? endValue.margin,
       );
     }
 
     return this;
+  }
+
+  @override
+  EdgeInsets marginNeeded() {
+    return margin;
   }
 
   @override

--- a/test/golden/complex/showcase_test.dart
+++ b/test/golden/complex/showcase_test.dart
@@ -109,7 +109,8 @@ void main() {
               ),
               backgroundDecorations: [
                 GridDecoration(
-                  endWithChart: true,
+                  endWithChartVertical: true,
+                  endWithChartHorizontal: true,
                   showHorizontalValues: true,
                   showVerticalGrid: false,
                   showVerticalValues: true,
@@ -310,9 +311,7 @@ void main() {
               itemOptions: BubbleItemOptions(
                 maxBarWidth: 2.0,
                 bubbleItemBuilder: (data) {
-                  return BubbleItem(
-                    color:  [Color(0xFF5B6ACF), Color(0xFFB6CADD)][data.listKey]
-                  );
+                  return BubbleItem(color: [Color(0xFF5B6ACF), Color(0xFFB6CADD)][data.listKey]);
                 },
                 multiItemStack: true,
               ),
@@ -394,15 +393,15 @@ void main() {
                 axisMin: -14,
               ),
               itemOptions: BarItemOptions(
-                  padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                  barItemBuilder: (data) {
-                    return BarItem(
-                      radius: BorderRadius.vertical(top: Radius.circular(12.0)),
-                      color: [Color(0xFF0139A4), Color(0xFF00B6E6)][data.listKey],
-                    );
-                  },
-                  multiItemStack: true,
-                ),
+                padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                barItemBuilder: (data) {
+                  return BarItem(
+                    radius: BorderRadius.vertical(top: Radius.circular(12.0)),
+                    color: [Color(0xFF0139A4), Color(0xFF00B6E6)][data.listKey],
+                  );
+                },
+                multiItemStack: true,
+              ),
               backgroundDecorations: [
                 GridDecoration(
                   horizontalAxisStep: 7.0,

--- a/test/golden/decoration/grid_decoration_test.dart
+++ b/test/golden/decoration/grid_decoration_test.dart
@@ -25,8 +25,7 @@ void main() {
             showHorizontalValues: true,
             showVerticalValues: false,
             textStyle: defaultTextStyle,
-            horizontalValuesPadding:
-                const EdgeInsets.only(right: 8.0, left: 8.0),
+            horizontalValuesPadding: const EdgeInsets.only(right: 8.0, left: 8.0),
           ),
         ]),
       )
@@ -48,8 +47,7 @@ void main() {
             showHorizontalValues: true,
             showVerticalValues: true,
             textStyle: defaultTextStyle,
-            horizontalValuesPadding:
-                const EdgeInsets.only(right: 8.0, left: 8.0),
+            horizontalValuesPadding: const EdgeInsets.only(right: 8.0, left: 8.0),
             verticalValuesPadding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
           ),
         ]),
@@ -63,8 +61,7 @@ void main() {
             horizontalLegendPosition: HorizontalLegendPosition.start,
             verticalLegendPosition: VerticalLegendPosition.top,
             textStyle: defaultTextStyle,
-            horizontalValuesPadding:
-                const EdgeInsets.only(right: 8.0, left: 8.0),
+            horizontalValuesPadding: const EdgeInsets.only(right: 8.0, left: 8.0),
             verticalValuesPadding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
           ),
         ]),
@@ -77,8 +74,7 @@ void main() {
             showVerticalValues: true,
             dashArray: [10, 10],
             textStyle: defaultTextStyle,
-            horizontalValuesPadding:
-                const EdgeInsets.only(right: 8.0, left: 8.0),
+            horizontalValuesPadding: const EdgeInsets.only(right: 8.0, left: 8.0),
             verticalValuesPadding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
           ),
         ]),
@@ -91,8 +87,7 @@ void main() {
             showVerticalValues: true,
             verticalAxisStep: 4,
             textStyle: defaultTextStyle,
-            horizontalValuesPadding:
-                const EdgeInsets.only(right: 8.0, left: 8.0),
+            horizontalValuesPadding: const EdgeInsets.only(right: 8.0, left: 8.0),
             verticalValuesPadding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
           ),
         ]),
@@ -111,16 +106,15 @@ void main() {
           GridDecoration(
             showHorizontalValues: true,
             showVerticalValues: true,
-            endWithChart: true,
+            endWithChartVertical: true,
+            endWithChartHorizontal: true,
             textStyle: defaultTextStyle,
-            horizontalValuesPadding:
-                const EdgeInsets.only(right: 8.0, left: 8.0),
+            horizontalValuesPadding: const EdgeInsets.only(right: 8.0, left: 8.0),
             verticalValuesPadding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
           ),
         ]),
       );
-    await tester.pumpWidgetBuilder(builder.build(),
-        surfaceSize: const Size(1400, 1000), textScaleSize: 1.4);
+    await tester.pumpWidgetBuilder(builder.build(), surfaceSize: const Size(1400, 1000), textScaleSize: 1.4);
     await screenMatchesGolden(tester, 'grid_decoration_golden');
   });
 }

--- a/test/golden/decoration/vertical_decoration_test.dart
+++ b/test/golden/decoration/vertical_decoration_test.dart
@@ -67,8 +67,7 @@ void main() {
               valuesPadding: const EdgeInsets.only(top: 8.0, bottom: 4.0)),
         ]),
       );
-    await tester.pumpWidgetBuilder(builder.build(),
-        surfaceSize: const Size(1400, 660), textScaleSize: 1.4);
+    await tester.pumpWidgetBuilder(builder.build(), surfaceSize: const Size(1400, 660), textScaleSize: 1.4);
     await screenMatchesGolden(tester, 'vertical_decoration_golden');
   });
 }

--- a/test/golden/examples/example_golden_test.dart
+++ b/test/golden/examples/example_golden_test.dart
@@ -11,17 +11,14 @@ void main() {
           height: 600.0,
           state: ChartState.line(
             ChartData.fromList(
-              <double>[1, 3, 4, 2, 7, 6, 2, 5, 4]
-                  .map((e) => BubbleValue<void>(e))
-                  .toList(),
+              <double>[1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BubbleValue<void>(e)).toList(),
             ),
             itemOptions: BubbleItemOptions(),
           ),
         ),
       ),
     );
-    await expectLater(find.byType(Padding),
-        matchesGoldenFile('goldens/simple_line_chart.png'));
+    await expectLater(find.byType(Padding), matchesGoldenFile('goldens/simple_line_chart.png'));
   });
 
   testWidgets('Simple bar chart', (tester) async {
@@ -32,17 +29,14 @@ void main() {
           height: 600.0,
           state: ChartState.bar(
             ChartData.fromList(
-              <double>[1, 3, 4, 2, 7, 6, 2, 5, 4]
-                  .map((e) => BarValue<void>(e))
-                  .toList(),
+              <double>[1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BarValue<void>(e)).toList(),
             ),
             itemOptions: BarItemOptions(),
           ),
         ),
       ),
     );
-    await expectLater(find.byType(Padding),
-        matchesGoldenFile('goldens/simple_bar_chart.png'));
+    await expectLater(find.byType(Padding), matchesGoldenFile('goldens/simple_bar_chart.png'));
   });
 
   testWidgets('Bar chart', (tester) async {
@@ -52,10 +46,7 @@ void main() {
         child: Chart<void>(
           height: 600.0,
           state: ChartState(
-            ChartData.fromList(
-                [1, 3, 4, 2, 7, 6, 2, 5, 4]
-                    .map((e) => BarValue<void>(e.toDouble()))
-                    .toList(),
+            ChartData.fromList([1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BarValue<void>(e.toDouble())).toList(),
                 axisMax: 8.0),
             itemOptions: BarItemOptions(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -78,8 +69,7 @@ void main() {
         ),
       ),
     );
-    await expectLater(
-        find.byType(Padding), matchesGoldenFile('goldens/bar_chart.png'));
+    await expectLater(find.byType(Padding), matchesGoldenFile('goldens/bar_chart.png'));
   });
 
   testWidgets('Line chart', (tester) async {
@@ -89,10 +79,7 @@ void main() {
         child: Chart<void>(
           height: 600.0,
           state: ChartState(
-            ChartData.fromList(
-                [1, 3, 4, 2, 7, 6, 2, 5, 4]
-                    .map((e) => BubbleValue<void>(e.toDouble()))
-                    .toList(),
+            ChartData.fromList([1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BubbleValue<void>(e.toDouble())).toList(),
                 axisMax: 8.0),
             itemOptions: BubbleItemOptions(
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -112,8 +99,7 @@ void main() {
         ),
       ),
     );
-    await expectLater(
-        find.byType(Padding), matchesGoldenFile('goldens/line_chart.png'));
+    await expectLater(find.byType(Padding), matchesGoldenFile('goldens/line_chart.png'));
   });
 
   testWidgets('Multi line chart', (tester) async {
@@ -125,22 +111,18 @@ void main() {
           state: ChartState(
             ChartData(
               [
-                [1, 3, 4, 2, 7, 6, 2, 5, 4]
-                    .map((e) => BubbleValue<void>(e.toDouble()))
-                    .toList(),
-                [4, 6, 3, 3, 2, 1, 4, 7, 5]
-                    .map((e) => BubbleValue<void>(e.toDouble()))
-                    .toList(),
+                [1, 3, 4, 2, 7, 6, 2, 5, 4].map((e) => BubbleValue<void>(e.toDouble())).toList(),
+                [4, 6, 3, 3, 2, 1, 4, 7, 5].map((e) => BubbleValue<void>(e.toDouble())).toList(),
               ],
               axisMax: 8.0,
             ),
             itemOptions: BubbleItemOptions(
-                padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                maxBarWidth: 4.0,
-                bubbleItemBuilder: (data) {
-                  return BubbleItem(color: [Colors.red, Colors.blue][data.listKey]);
-                },
-              ),
+              padding: const EdgeInsets.symmetric(horizontal: 8.0),
+              maxBarWidth: 4.0,
+              bubbleItemBuilder: (data) {
+                return BubbleItem(color: [Colors.red, Colors.blue][data.listKey]);
+              },
+            ),
             backgroundDecorations: [
               GridDecoration(
                 verticalAxisStep: 1,
@@ -161,7 +143,6 @@ void main() {
         ),
       ),
     );
-    await expectLater(find.byType(Padding),
-        matchesGoldenFile('goldens/multi_line_chart.png'));
+    await expectLater(find.byType(Padding), matchesGoldenFile('goldens/multi_line_chart.png'));
   });
 }


### PR DESCRIPTION
Added apple charts demo
![Screenshot 2022-10-21 at 13 51 10](https://user-images.githubusercontent.com/59824861/197207102-69296ca8-b917-4f92-8e89-3f71a722a419.png)

Had to change few things in `WidgetDecoration` as well as `Horizontal` and `Vertical` Decorations. 

Grid decoration has also been redone in much simpler way.

Grid decoration no longer has `endWithChart` instead 2 new fields are added:
`endWithChartHorizontal` and `endWithChartVertical`