### PR TITLE
Enable hit testing on decorations and items

### DIFF
--- a/example/lib/charts/candle_chart_screen.dart
+++ b/example/lib/charts/candle_chart_screen.dart
@@ -90,7 +90,7 @@ class _CandleChartScreenState extends State<CandleChartScreen> {
                 ),
                 chartBehaviour: ChartBehaviour(onItemClicked: (item) {
                   setState(() {
-                    _selected = item;
+                    _selected = item.itemKey;
                   });
                 }),
                 backgroundDecorations: [

--- a/example/lib/charts/scrollable_chart_screen.dart
+++ b/example/lib/charts/scrollable_chart_screen.dart
@@ -93,7 +93,7 @@ class _ScrollableChartScreenState extends State<ScrollableChartScreen> {
         isScrollable: _isScrollable,
         onItemClicked: (item) {
           setState(() {
-            _selected = item;
+            _selected = item.itemKey;
           });
         },
       ),

--- a/example/lib/click_test.dart
+++ b/example/lib/click_test.dart
@@ -25,26 +25,27 @@ class _ChartAppState extends State<ChartApp> {
         state: ChartState(
             data: ChartData(
               [
-                [2, 4, 6, 3, 2, 5, 4, 3, 2]
-                    .map((e) => ChartItem<void>(e.toDouble()))
-                    .toList(),
+                [2, 4, 6, 3, 2, 5, 4, 3, 2].map((e) => ChartItem<void>(e.toDouble())).toList(),
               ],
               valueAxisMaxOver: 2,
             ),
             itemOptions: BarItemOptions(
               barItemBuilder: (_) => BarItem(),
               padding: const EdgeInsets.symmetric(horizontal: 8.0),
-            ), behaviour: ChartBehaviour(
-          onItemClicked: (index) {
-            setState(() {
-              _selectedIndex = index;
-            });
-          },
-        ), backgroundDecorations: [
-          GridDecoration(),
-        ], foregroundDecorations: [
-          SelectedItemDecoration(_selectedIndex),
-        ]),
+            ),
+            behaviour: ChartBehaviour(
+              onItemClicked: (index) {
+                setState(() {
+                  _selectedIndex = index.itemKey;
+                });
+              },
+            ),
+            backgroundDecorations: [
+              GridDecoration(),
+            ],
+            foregroundDecorations: [
+              SelectedItemDecoration(_selectedIndex),
+            ]),
       ),
     );
   }

--- a/lib/chart/model/chart_state.dart
+++ b/lib/chart/model/chart_state.dart
@@ -21,8 +21,7 @@ class ChartState<T> {
     this.behaviour = const ChartBehaviour(),
     this.backgroundDecorations = const <DecorationPainter>[],
     this.foregroundDecorations = const <DecorationPainter>[],
-  })
-      : assert(data.isNotEmpty, 'No items!'),
+  })  : assert(data.isNotEmpty, 'No items!'),
         defaultPadding = EdgeInsets.zero,
         defaultMargin = EdgeInsets.zero,
         dataRenderer = (itemOptions is WidgetItemOptions
@@ -34,7 +33,8 @@ class ChartState<T> {
 
   /// Create line chart with foreground sparkline decoration and background grid decoration
   @Deprecated('Use ChartState(foregroundDecorations: [SparkLineDecoration()])')
-  factory ChartState.line(ChartData<T> data, {
+  factory ChartState.line(
+    ChartData<T> data, {
     required BubbleItemOptions itemOptions,
     ChartBehaviour behaviour = const ChartBehaviour(),
     List<DecorationPainter> backgroundDecorations = const <DecorationPainter>[],
@@ -51,7 +51,8 @@ class ChartState<T> {
 
   /// Create bar chart with background grid decoration
   @Deprecated('Use ChartState(itemOptions: BarItemOptions())')
-  factory ChartState.bar(ChartData<T> data, {
+  factory ChartState.bar(
+    ChartData<T> data, {
     required BarItemOptions itemOptions,
     ChartBehaviour behaviour = const ChartBehaviour(),
     List<DecorationPainter> backgroundDecorations = const <DecorationPainter>[],
@@ -66,7 +67,8 @@ class ChartState<T> {
     );
   }
 
-  ChartState._lerp(this.data, {
+  ChartState._lerp(
+    this.data, {
     this.behaviour = const ChartBehaviour(),
     this.backgroundDecorations = const [],
     this.foregroundDecorations = const [],
@@ -182,20 +184,18 @@ class ChartState<T> {
           chartState,
           chartState.data.items
               .mapIndexed(
-                (lineKey, items) =>
-                items
-                    .mapIndexed((itemKey, item) =>
-                    LeafChartItemRenderer(
-                      item,
-                      chartState.data,
-                      itemOptions,
-                      itemKey: itemKey,
-                      listKey: lineKey,
-                      drawDataItem:
-                      itemOptions.itemBuilder(ItemBuilderData<T?>(item, itemKey, lineKey)) as DrawDataItem,
-                    ))
+                (lineKey, items) => items
+                    .mapIndexed((itemKey, item) => LeafChartItemRenderer(
+                          item,
+                          chartState,
+                          itemOptions,
+                          itemKey: itemKey,
+                          listKey: lineKey,
+                          drawDataItem:
+                              itemOptions.itemBuilder(ItemBuilderData<T?>(item, itemKey, lineKey)) as DrawDataItem,
+                        ))
                     .toList(),
-          )
+              )
               .expand((element) => element)
               .toList());
     };
@@ -204,27 +204,26 @@ class ChartState<T> {
   /// It can render chart items as widgets, and it only accepts [WidgetItemOptions] since it needs the
   /// [WidgetItemOptions.widgetItemBuilder] to build the chart item widgets.
   static ChartDataRendererFactory<T?> _widgetItemRenderer<T>(WidgetItemOptions itemOptions) {
-    return (chartState) =>
-        ChartLinearDataRenderer<T>(
-            chartState,
-            chartState.data.items
-                .mapIndexed(
-                  (lineKey, items) {
+    return (chartState) => ChartLinearDataRenderer<T>(
+        chartState,
+        chartState.data.items
+            .mapIndexed(
+              (lineKey, items) {
                 return items
                     .mapIndexed(
-                      (itemKey, e) =>
-                      ChildChartItemRenderer<T?>(
+                      (itemKey, e) => ChildChartItemRenderer<T?>(
                         e,
-                        chartState.data,
+                        chartState,
                         itemOptions,
-                        arrayKey: lineKey,
+                        itemKey: itemKey,
+                        listKey: lineKey,
                         child: itemOptions.widgetItemBuilder(ItemBuilderData<T?>(e, itemKey, lineKey)),
                       ),
-                )
+                    )
                     .toList();
               },
             )
-                .expand((element) => element)
-                .toList());
+            .expand((element) => element)
+            .toList());
   }
 }

--- a/lib/chart/model/theme/chart_behaviour.dart
+++ b/lib/chart/model/theme/chart_behaviour.dart
@@ -21,21 +21,16 @@ class ChartBehaviour {
 
   /// Return index of item clicked. Since graph can be multi value, user
   /// will have to handle clicked index to show data they want to show
-  final ValueChanged<int>? onItemClicked;
+  final ValueChanged<ItemBuilderData>? onItemClicked;
 
   /// Return true if chart is currently scrollable
   bool get isScrollable => _isScrollable > 0.5;
-
-  void _onChartItemClicked(int index) {
-    onItemClicked?.call(index);
-  }
 
   /// Animate Behaviour from one state to other
   static ChartBehaviour lerp(ChartBehaviour a, ChartBehaviour b, double t) {
     // This values should never return null, this is for null-safety
     // But if it somehow does occur, then revert to default values
-    final _scrollableLerp =
-        lerpDouble(a._isScrollable, b._isScrollable, t) ?? 0.0;
+    final _scrollableLerp = lerpDouble(a._isScrollable, b._isScrollable, t) ?? 0.0;
 
     return ChartBehaviour._lerp(
       _scrollableLerp,

--- a/lib/chart/render/chart_renderer.dart
+++ b/lib/chart/render/chart_renderer.dart
@@ -53,6 +53,11 @@ class _ChartRenderObject<T> extends RenderBox
   }
 
   @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return defaultHitTestChildren(result, position: position);
+  }
+
+  @override
   void performLayout() {
     var child = firstChild;
 

--- a/lib/chart/render/data_renderer/chart_linear_data_renderer.dart
+++ b/lib/chart/render/data_renderer/chart_linear_data_renderer.dart
@@ -3,8 +3,7 @@ part of charts_painter;
 /// Align chart data items in linear fashion. Meaning X axis cannot be changed. X axis becomes the index of current item
 /// height of the item is defined by item max or min value.
 class ChartLinearDataRenderer<T> extends ChartDataRenderer<T> {
-  ChartLinearDataRenderer(this.chartState, List<Widget> children, {Key? key})
-      : super(key: key, children: children);
+  ChartLinearDataRenderer(this.chartState, List<Widget> children, {Key? key}) : super(key: key, children: children);
 
   final ChartState<T?> chartState;
 
@@ -14,8 +13,7 @@ class ChartLinearDataRenderer<T> extends ChartDataRenderer<T> {
   }
 
   @override
-  void updateRenderObject(
-      BuildContext context, _ChartLinearItemRenderer<T?> renderObject) {
+  void updateRenderObject(BuildContext context, _ChartLinearItemRenderer<T?> renderObject) {
     renderObject.chartState = chartState;
     renderObject.markNeedsLayout();
   }
@@ -71,12 +69,11 @@ class _ChartLinearItemRenderer<T> extends ChartItemRenderer<T>
           currentValue: _currentValue,
         );
 
-
         assert(child.parentData == childParentData);
         child = childParentData.nextSibling;
         childCount[key] = _currentValue + 1;
       } else if (child is _RenderChildChartItem<T>) {
-        final key = child.key;
+        final key = child.listKey;
         final _currentValue = (childCount[key] ?? 0).toInt();
 
         _setWidgetChildPosition(
@@ -94,6 +91,11 @@ class _ChartLinearItemRenderer<T> extends ChartItemRenderer<T>
     }
 
     size = _size;
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return defaultHitTestChildren(result, position: position);
   }
 
   @override
@@ -149,18 +151,15 @@ class _ChartLinearItemRenderer<T> extends ChartItemRenderer<T>
     final _verticalMultiplier = size.height / max(1, _maxValue);
     // In case we have multiple data and we have [WidgetItemOptions.multiValuePadding] set to true then
     // we need to add padding to the item, and change the starting offset.
-    final _multiValuePadding =
-        chartState.itemOptions.multiValuePadding;
+    final _multiValuePadding = chartState.itemOptions.multiValuePadding;
 
     // Animated multiValueStacked value (goes from 0.0 meaning no stack - to 1.0 stack)
-    final _stack =
-        1 - chartState.data.dataStrategy._stackMultipleValuesProgress;
+    final _stack = 1 - chartState.data.dataStrategy._stackMultipleValuesProgress;
     // How many items will we fit in the vertical space
     final _stackSize = max(1.0, (chartState.data.stackSize) * _stack);
 
     // Get available size for item. Subtracts set padding and divide by number of items we want to show
-    final _stackWidth =
-        (itemWidth - (_multiValuePadding.horizontal * _stack)) / _stackSize;
+    final _stackWidth = (itemWidth - (_multiValuePadding.horizontal * _stack)) / _stackSize;
 
     // For `StackDataStrategy` we will cut stacked items at the bottom, this will make sure there is no
     // Widget overlap for drawing, and make sure that centered widgets are in the center of visible item
@@ -168,22 +167,20 @@ class _ChartLinearItemRenderer<T> extends ChartItemRenderer<T>
 
     childParentData.offset = offset + // Current chart offset
         // Item offset in the list
-        Offset(itemWidth * currentValue,
-            size.height - ((child.item.max ?? 0.0) * _verticalMultiplier)) +
+        Offset(itemWidth * currentValue, size.height - ((child.item.max ?? 0.0) * _verticalMultiplier)) +
         // MultiValuePadding offset
         Offset(_multiValuePadding.left * _stack, 0);
 
     // Handle stack data strategy.
     if (chartState.data.dataStrategy is StackDataStrategy) {
-      if (child.key + 1 < chartState.data.stackSize) {
-        bottomPaddingHeight = (chartState.data.items[child.key + 1][currentValue].max ?? 0.0) * (1 - _stack);
+      if (child.listKey + 1 < chartState.data.stackSize) {
+        bottomPaddingHeight = (chartState.data.items[child.listKey + 1][currentValue].max ?? 0.0) * (1 - _stack);
       }
     }
 
     final innerConstraints = BoxConstraints.tightFor(
       width: _stackWidth,
-      height: ((child.item.max ?? 0.0) * _verticalMultiplier) -
-          (bottomPaddingHeight * _verticalMultiplier),
+      height: ((child.item.max ?? 0.0) * _verticalMultiplier) - (bottomPaddingHeight * _verticalMultiplier),
     );
 
     child.layout(innerConstraints, parentUsesSize: true);

--- a/lib/chart/render/decorations/renderer/decorations_renderer.dart
+++ b/lib/chart/render/decorations/renderer/decorations_renderer.dart
@@ -1,12 +1,8 @@
 part of charts_painter;
 
 class DecorationsRenderer<T> extends MultiChildRenderObjectWidget {
-  DecorationsRenderer(List<DecorationPainter> fixedDecoration, this.chartState,
-      {Key? key})
-      : super(
-            key: key,
-            children:
-                fixedDecoration.map((e) => e.getRenderer(chartState)).toList());
+  DecorationsRenderer(List<DecorationPainter> fixedDecoration, this.chartState, {Key? key})
+      : super(key: key, children: fixedDecoration.map((e) => e.getRenderer(chartState)).toList());
 
   final ChartState<T?> chartState;
 
@@ -16,8 +12,7 @@ class DecorationsRenderer<T> extends MultiChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(
-      BuildContext context, _FixedDecorationRenderObject<T?> renderObject) {
+  void updateRenderObject(BuildContext context, _FixedDecorationRenderObject<T?> renderObject) {
     renderObject.chartState = chartState;
     renderObject.markNeedsLayout();
   }
@@ -57,6 +52,11 @@ class _FixedDecorationRenderObject<T> extends RenderBox
     }
 
     size = constraints.biggest;
+  }
+
+  @override
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+    return defaultHitTestChildren(result, position: position);
   }
 
   @override

--- a/lib/chart/widgets/chart_widget.dart
+++ b/lib/chart/widgets/chart_widget.dart
@@ -18,70 +18,31 @@ class _ChartWidget<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return LayoutBuilder(
       builder: (context, constraints) {
         // What size does the item want to be?
-        final _wantedItemWidth = state.data.items.foldIndexed<double>(0.0,
-            (index, double prevValue, _) {
-          return max(
-              prevValue,
-              max(state.itemOptions.minBarWidth ?? 0.0,
-                  state.itemOptions.maxBarWidth ?? 0.0));
+        final _wantedItemWidth = state.data.items.foldIndexed<double>(0.0, (index, double prevValue, _) {
+          return max(prevValue, max(state.itemOptions.minBarWidth ?? 0.0, state.itemOptions.maxBarWidth ?? 0.0));
         });
 
-        final _width =
-            constraints.maxWidth.isFinite ? constraints.maxWidth : width!;
-        final _height =
-            constraints.maxHeight.isFinite ? constraints.maxHeight : height!;
+        final _width = constraints.maxWidth.isFinite ? constraints.maxWidth : width!;
+        final _height = constraints.maxHeight.isFinite ? constraints.maxHeight : height!;
 
         final _listSize = state.data.listSize;
 
-        final _horizontalPadding = state.data.items.foldIndexed<double>(0.0,
-            (index, double prevValue, _) {
-          return max(
-              prevValue, state.itemOptions.padding.horizontal);
+        final _horizontalPadding = state.data.items.foldIndexed<double>(0.0, (index, double prevValue, _) {
+          return max(prevValue, state.itemOptions.padding.horizontal);
         });
 
         final _size = Size(
-            _width +
-                (((_wantedItemWidth + _horizontalPadding) * _listSize) -
-                        _width) *
-                    state.behaviour._isScrollable,
+            _width + (((_wantedItemWidth + _horizontalPadding) * _listSize) - _width) * state.behaviour._isScrollable,
             _height);
 
-        final _chart = Container(
+        return Container(
           constraints: BoxConstraints.tight(_size),
           child: ChartRenderer(state),
         );
-
-        // If chart is clickable, then wrap it with [GestureDetector]
-        // for detecting clicks, and sending item index to [onChartItemClicked]
-        if (state.behaviour.onItemClicked != null) {
-          final size = state.defaultPadding.deflateSize(_size);
-
-          final _constraintSize = constraints.biggest;
-          final _constraint = state.defaultPadding.deflateSize(_constraintSize);
-          final _itemWidth =
-              (size.width.isFinite ? size.width : _constraint.width) /
-                  _listSize;
-
-          return GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTapDown: (tapDetails) => state.behaviour._onChartItemClicked(
-                _getClickLocation(_itemWidth, tapDetails.localPosition)),
-            onPanUpdate: (panUpdate) => state.behaviour._onChartItemClicked(
-                _getClickLocation(_itemWidth, panUpdate.localPosition)),
-            child: _chart,
-          );
-        }
-
-        return _chart;
       },
     );
-  }
-
-  int _getClickLocation(double _itemWidth, Offset offset) {
-    return (offset.dx / _itemWidth).floor();
   }
 }


### PR DESCRIPTION
Enable hit testing on widget decorations and widget items. This allows them to have a GestureDetector.