### PR TITLE
Added .fromItem constructor to BarChart

### DIFF
--- a/example/lib/widgets/bar_chart.dart
+++ b/example/lib/widgets/bar_chart.dart
@@ -16,7 +16,21 @@ class BarChart<T> extends StatelessWidget {
     this.itemOptions = const BarItemOptions(),
     this.stack = false,
     Key? key,
-  })  : _mappedValues = [data.map((e) => BarValue<T>(dataToValue(e))).toList()],
+  })  : _mappedValues = [
+          data.map((e) => ChartItem<T>(dataToValue(e))).toList()
+        ],
+        super(key: key);
+
+  BarChart.fromItem({
+    required List<ChartItem<T>> data,
+    this.height = 240.0,
+    this.backgroundDecorations = const [],
+    this.foregroundDecorations = const [],
+    this.chartBehaviour = const ChartBehaviour(),
+    this.itemOptions = const BarItemOptions(),
+    this.stack = false,
+    Key? key,
+  })  : _mappedValues = [data],
         super(key: key);
 
   const BarChart.map(
@@ -30,7 +44,7 @@ class BarChart<T> extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
-  final List<List<BarValue<T>>> _mappedValues;
+  final List<List<ChartItem<T>>> _mappedValues;
   final double height;
 
   final bool stack;


### PR DESCRIPTION
I did this to allow me to use the CharItem value from the data: property in the BarChart, example:

```
return BarChart.fromItem(
      data: [
        ChartItem(32.52, value: {
          'title': 'De 1 á\n16 dias',
          'value': '32.52',
        }),
        ChartItem(15.8, value: {
          'title': 'De 16 á\n30 dias',
          'value': '15.8',
        }),
        ChartItem(15.97, value: {
          'title': 'De 31 á\n60 dias',
          'value': '15.97',
        }),
      ],
      itemOptions: WidgetItemOptions(
        widgetItemBuilder: (data) {
          print(data.item);

          return Container(
            decoration: BoxDecoration(
              color: Theme.of(context).colorScheme.primary,
            ),
            margin: EdgeInsets.symmetric(horizontal: 4.0),
            child: RotatedBox(
              quarterTurns: 1,
              child: Align(
                alignment: Alignment.centerLeft,
                child: Padding(
                  padding: const EdgeInsets.symmetric(
                    vertical: 2.0,
                    horizontal: 8.0,
                  ),
                  child: Text('${data.item.max}%'),
                ),
              ),
            ),
          );
        },
      ),
    );
```

In this example I can use my custom property 'title' to dynamically draw it while rendering the bar.

Without this the only thing I have from my `ChartItem` is the max property, and it also makes the API simpler.